### PR TITLE
Add context resolve data-manager to init routing

### DIFF
--- a/lib/filesync.js
+++ b/lib/filesync.js
@@ -33,7 +33,7 @@ class Filesync {
         throw new Error('Implement');
     }
 
-    getFilepathForEntity(entity){
+    getFilepathForEntity(entity) {
         let basepath = this.remote.path;
         let filename = this.getFilenameFromEntity(entity);
         return path.join(basepath, filename);

--- a/lib/init.js
+++ b/lib/init.js
@@ -15,16 +15,20 @@ module.exports = function(context, config) {
      */
     config = extend({}, DEFAULTS, config);
 
-    /*
-     * Expose some utility functions through the
-     * filesync object.
-     */
-    var filesync = new Filesync(context, config);
-
     //Move to command!! :)
-    context.on(config.filesyncEventType, (topic, message)=>{
+    context.on(config.filesyncEventType, (topic, message) => {
         _logger.info('filesync: remote file updated');
     });
 
-    return filesync;
+    return new Promise(function(resolve, reject) {
+
+        context.resolve('datamanager').then(()=>{
+            /*
+             * Expose some utility functions through the
+             * filesync object.
+             */
+            var filesync = new Filesync(context, config);
+            resolve(filesync);
+        });
+    });
 };


### PR DESCRIPTION
This closes #4 by waiting for `datamanager` to be resolved before triggering the Filesync initial routing.